### PR TITLE
Fix resolution of relative main paths in Pulumi.yaml

### DIFF
--- a/proti-core/src/pulumi-project.ts
+++ b/proti-core/src/pulumi-project.ts
@@ -21,7 +21,7 @@ export const readPulumiProject = async (projectFile: string): Promise<PulumiProj
 		projectFile,
 		main:
 			typeof project.main === 'string'
-				? path.resolve(projectFile, project.main)
+				? path.resolve(path.dirname(projectFile), project.main)
 				: path.dirname(projectFile),
 		...(typeof project.name === 'string' ? { name: project.name } : {}),
 		...(typeof project.description === 'string' ? { description: project.description } : {}),

--- a/proti-core/test/pulumi-project.test.ts
+++ b/proti-core/test/pulumi-project.test.ts
@@ -3,35 +3,33 @@ import * as path from 'path';
 import { PulumiProject, readPulumiProject } from '../src/pulumi-project';
 
 describe('pulumi project', () => {
-	const validProjects: (Omit<PulumiProject, 'main'> & Partial<PulumiProject>)[] = [
-		{ projectFile: 'pulumi-project/Pulumi.yaml' },
+	/**
+	 * Expected project configs for Pulumi project YAML files in the ./pulumi-project/ subdirectory
+	 */
+	const validProjects: PulumiProject[] = [
 		{
-			projectFile: 'pulumi-project/Pulumi2.yaml',
+			projectFile: path.resolve(__dirname, 'pulumi-project/Pulumi.yaml'),
+			main: path.resolve(__dirname, 'pulumi-project'),
+		},
+		{
+			projectFile: path.resolve(__dirname, 'pulumi-project/Pulumi2.yaml'),
+			main: path.resolve(__dirname, 'pulumi-project'),
 			name: 'test',
 			description: 'A minimal AWS TypeScript Pulumi program',
 		},
 		{
-			projectFile: 'pulumi-project/Pulumi3.yaml',
+			projectFile: path.resolve(__dirname, 'pulumi-project/Pulumi3.yaml'),
 			main: '/hello/world.ts',
 			name: 'test',
 			description: 'A minimal AWS TypeScript Pulumi program',
 		},
+		{
+			projectFile: path.resolve(__dirname, 'pulumi-project/Pulumi4.yaml'),
+			main: path.resolve(__dirname, 'pulumi-project/hello/world.ts'),
+		},
 	];
-
-	it.each(
-		validProjects.map((partialProject) => {
-			const projectFile = path.resolve(__dirname, partialProject.projectFile);
-			return [
-				projectFile,
-				{
-					...partialProject,
-					projectFile,
-					main: partialProject.main || path.dirname(projectFile),
-				},
-			];
-		})
-	)('should load %s', (projectFile, project) =>
-		expect(readPulumiProject(projectFile)).resolves.toStrictEqual(project)
+	it.each(validProjects)('should load %s', (project) =>
+		expect(readPulumiProject(project.projectFile)).resolves.toStrictEqual(project)
 	);
 
 	it('should throw on invalid path', () => {

--- a/proti-core/test/pulumi-project/Pulumi4.yaml
+++ b/proti-core/test/pulumi-project/Pulumi4.yaml
@@ -1,0 +1,2 @@
+runtime: nodejs
+main: hello/world.ts


### PR DESCRIPTION
Found and reported by @davidspielmann, thanks!

If the Pulumi project configures a relative path for `main` in the `Pulumi.yaml`, ProTI resolved it wrong. For example: `a/b` in `/c/Pulumi.yaml` was resolved to `/c/Pulumi.yaml/a/b` instead of the correct `/c/a/b`.

This PR adds a corresponding test and fixes the issue.