### PR TITLE
Print all error causes with a message

### DIFF
--- a/proti-test-runner/src/test-result.ts
+++ b/proti-test-runner/src/test-result.ts
@@ -46,7 +46,7 @@ const hasFailed = (result: Result): boolean => result.errors.length > 0;
 
 const toErrorMessage = (error: Error): string =>
 	(error.stack ? error.stack : error.message) +
-	(error.cause instanceof Error || (error.cause as any)?.name === 'Error' // If error happened in other frame, instanceof Error is false
+	(error.cause instanceof Error || typeof (error.cause as any)?.message === 'string' // If error happened in other frame, instanceof Error is false
 		? `\ncaused by ${toErrorMessage(error.cause as Error)}`
 		: '');
 


### PR DESCRIPTION
If an error was thrown with another instance of the `Error` class in the prototype chain, `instanceof` does not detect the error object as error. With `(error.cause as any)?.name === 'Error'` we intended to solve this issue, but did so only for direct instance of `Error`, not for sublcasses of it. There is no point in being so strict here: If an object has a message field that is a string, why not just assuming it is a message, which also solves the subclassing issue...