### PR TITLE
Add dedicated test phase for ProTI plugin loading

### DIFF
--- a/proti-core/test/test-coordinator.test.ts
+++ b/proti-core/test/test-coordinator.test.ts
@@ -15,14 +15,13 @@ describe('test coordinator', () => {
 	};
 
 	describe('loading test oracles', () => {
-		const coordinatorForOracles = (oracles: string[]): TestCoordinator =>
-			new TestCoordinator({ ...defaultTestCoordinatorConfig(), oracles }, testModuleConfig);
-
 		it('should not load oracles', async () => {
-			const coordinator = coordinatorForOracles([]);
-			Object.entries(await coordinator.oracles).forEach(([, oracles]) =>
-				expect(oracles.length).toBe(0)
-			);
+			Object.entries(
+				await TestCoordinator.loadOracles(
+					{ ...defaultTestCoordinatorConfig(), oracles: [] },
+					testModuleConfig
+				)
+			).forEach(([, oracles]) => expect(oracles.length).toBe(0));
 		});
 
 		type OracleTypes = 'resource' | 'asyncResource' | 'deployment' | 'asyncDeployment';
@@ -33,57 +32,70 @@ describe('test coordinator', () => {
 			['async deployment', ['async-deployment-oracle'], ['asyncDeployment']],
 			['combined', ['combined-oracle'], ['resource', 'asyncDeployment']],
 		])('should load %s oracle', async (_, files, types) => {
-			const coordinator = coordinatorForOracles(
-				files.map((file) => path.resolve(__dirname, './test-coordinator-tests/', file))
+			const oracles = await TestCoordinator.loadOracles(
+				{
+					...defaultTestCoordinatorConfig(),
+					oracles: files.map((file) =>
+						path.resolve(__dirname, './test-coordinator-tests/', file)
+					),
+				},
+				testModuleConfig
 			);
-			Object.entries(await coordinator.oracles).forEach(([type, oracles]) => {
-				expect(oracles.length).toBe(types.includes(type as OracleTypes) ? 1 : 0);
-				oracles.forEach((oracle: unknown) => expect(isOracle(oracle)).toBe(true));
+			Object.entries(oracles).forEach(([type, orcls]) => {
+				expect(orcls.length).toBe(types.includes(type as OracleTypes) ? 1 : 0);
+				orcls.forEach((oracle: unknown) => expect(isOracle(oracle)).toBe(true));
 			});
 		});
 
-		it('should fail on loading non-existing oracle', () =>
-			expect(() => coordinatorForOracles(['a']).oracles).rejects.toThrow(
-				/Cannot find module 'a' from /
-			));
+		it('should fail on loading non-existing oracle', () => {
+			const oracles = TestCoordinator.loadOracles(
+				{ ...defaultTestCoordinatorConfig(), oracles: ['a'] },
+				testModuleConfig
+			);
+			expect(oracles).rejects.toThrow(/Cannot find module 'a' from /);
+		});
 
 		it('should init loaded oracle module', async () => {
 			const initOraclePath = path.resolve(__dirname, './test-coordinator-tests/oracle-init');
 			// eslint-disable-next-line import/no-dynamic-require, global-require
 			const module = require(initOraclePath);
 			expect(module.config).toBe(undefined);
-			await coordinatorForOracles([initOraclePath]).oracles;
+			await TestCoordinator.loadOracles(
+				{ ...defaultTestCoordinatorConfig(), oracles: [initOraclePath] },
+				testModuleConfig
+			);
 			expect(module.config).toBe(testModuleConfig);
 		});
 	});
 
 	describe('loading generator arbitrary', () => {
-		const coordinatorForArbitrary = (arbitrary: string): TestCoordinator =>
-			new TestCoordinator(
-				{
-					...defaultTestCoordinatorConfig(),
-					arbitrary,
-				},
-				testModuleConfig
-			);
 		const arbPath = path.resolve(__dirname, './test-coordinator-tests/arbitrary');
 		const initArbPath = path.resolve(__dirname, './test-coordinator-tests/arbitrary-init');
 
 		it('should load arbitrary', async () => {
-			const coordinator = coordinatorForArbitrary(arbPath);
-			expect(is<fc.Arbitrary<Generator>>(await coordinator.arbitrary)).toBe(true);
+			const arb = await TestCoordinator.loadArbitrary(
+				{ ...defaultTestCoordinatorConfig(), arbitrary: arbPath },
+				testModuleConfig
+			);
+			expect(is<fc.Arbitrary<Generator>>(arb)).toBe(true);
 		});
 
-		it('should fail on loading non-existing arbitrary', () =>
-			expect(() => coordinatorForArbitrary('a').arbitrary).rejects.toThrow(
-				/Cannot find module 'a' from /
-			));
+		it('should fail on loading non-existing arbitrary', () => {
+			const arb = TestCoordinator.loadArbitrary(
+				{ ...defaultTestCoordinatorConfig(), arbitrary: 'a' },
+				testModuleConfig
+			);
+			expect(arb).rejects.toThrow(/Cannot find module 'a' from /);
+		});
 
 		it('should init loaded arbitrary module', async () => {
 			// eslint-disable-next-line import/no-dynamic-require, global-require
 			const module = require(initArbPath);
 			expect(module.config).toBe(undefined);
-			await coordinatorForArbitrary(initArbPath).arbitrary;
+			await TestCoordinator.loadArbitrary(
+				{ ...defaultTestCoordinatorConfig(), arbitrary: initArbPath },
+				testModuleConfig
+			);
 			expect(module.config).toBe(testModuleConfig);
 		});
 	});

--- a/proti-test-runner/src/test-runner.ts
+++ b/proti-test-runner/src/test-runner.ts
@@ -148,12 +148,14 @@ const runProti = async (
 		}
 	);
 
-	const testCoordinator = new TestCoordinator(proti.testCoordinator, {
-		moduleLoader,
-		pluginsConfig: proti.plugins,
-		testPath,
-		cacheDir: config.cacheDirectory,
-	});
+	const testCoordinator = await runAccompanyingTest('Load ProTI plugins', async () =>
+		TestCoordinator.create(proti.testCoordinator, {
+			moduleLoader,
+			pluginsConfig: proti.plugins,
+			testPath,
+			cacheDir: config.cacheDirectory,
+		})
+	);
 
 	// @proti-iac/spec ad-hoc specifications is enabled when used in the program and not explicitely disabled
 	const isSpecEnabled =
@@ -172,10 +174,7 @@ const runProti = async (
 		const unhandledRejection = new Promise<void>((_, reject) => {
 			notifyUnhandledRejection = reject;
 		}).catch(reportError);
-		const testRunCoordinator = await errMsg(
-			testCoordinator.newRunCoordinator(generator),
-			'Failed to initialize test run coordinator'
-		);
+		const testRunCoordinator = testCoordinator.newRunCoordinator(generator);
 		await runtime.isolateModulesAsync(async () => {
 			outputsWaiter.reset();
 			moduleLoader.mockModules(preloads);


### PR DESCRIPTION
ProTI plugin loading (incl. initialization) used to be triggered in the test runner setup, loading plugins asynchronously and eventually awaiting them in the test runs. With more advanced plugin init methods, debugging becomes harder because some errors have been reported as a failure of the first test run (confusing) or without an error message (problematic). With this change, we make the plugin loading an explicit phase that is awaited and gives us better error reporting. It also simplifies the test run coordinator setup.