### PR TITLE
Align name of ProTI's run test phase

### DIFF
--- a/proti-test-runner/src/test-runner.ts
+++ b/proti-test-runner/src/test-runner.ts
@@ -317,7 +317,7 @@ const testRunner = async (
 	const start = now();
 	const accompanyingResults: Result[] = [];
 	const runAccompanyingTest = makeAccompanyingTest((result) => accompanyingResults.push(result));
-	const checkResult = await runAccompanyingTest('Running ProTI', () =>
+	const checkResult = await runAccompanyingTest('Run ProTI', () =>
 		runProti(config, environment, runtime, testPath, runAccompanyingTest)
 	).catch(() => undefined);
 	return toTestResult({


### PR DESCRIPTION
Rename the "Running ProTI" phase to "Run ProTI" for linguistic consistency.