### PR TITLE
Add more information to plugin init interface

### DIFF
--- a/proti-core/package.json
+++ b/proti-core/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@jest/environment": "^29.7.0",
-    "@jest/transform": "^29.7.0",
     "@jest/types": "^29.6.3",
     "@types/jest": "^29.5.7",
     "@types/js-yaml": "^4.0.8",

--- a/proti-core/src/plugin.ts
+++ b/proti-core/src/plugin.ts
@@ -1,10 +1,25 @@
-import type { PluginsConfig } from './config';
+import type { JestEnvironment } from '@jest/environment';
+import type { Config } from '@jest/types';
+import type { IHasteFS } from 'jest-haste-map';
+import type Resolver from 'jest-resolve';
+import type Runtime from 'jest-runtime';
+import type { Config as ProtiConfig, PluginsConfig } from './config';
 import type { ModuleLoader } from './module-loader';
+import type { PulumiProject } from './pulumi-project';
+import type { DeepReadonly } from './utils';
 
 export type PluginArgs = Readonly<{
 	readonly testPath: string;
 	readonly cacheDir: string;
 	readonly moduleLoader: ModuleLoader;
 	readonly pluginsConfig: PluginsConfig;
+	readonly globalConfig: DeepReadonly<Config.GlobalConfig>;
+	readonly projectConfig: DeepReadonly<Config.ProjectConfig>;
+	readonly environment: JestEnvironment;
+	readonly resolver: Resolver;
+	readonly runtime: Runtime;
+	readonly hasteFS: IHasteFS;
+	readonly protiConfig: ProtiConfig;
+	readonly pulumiProject: PulumiProject;
 }>;
 export type PluginInitFn = (config: PluginArgs) => Promise<void>;

--- a/proti-core/test/test-coordinator.test.ts
+++ b/proti-core/test/test-coordinator.test.ts
@@ -8,12 +8,12 @@ import type { PluginArgs } from '../src/plugin';
 import { TestCoordinator } from '../src/test-coordinator';
 
 describe('test coordinator', () => {
-	const pluginArgs: PluginArgs = {
+	const pluginArgs = {
 		moduleLoader: new (jest.fn<ModuleLoader, []>())(),
 		pluginsConfig: defaultPluginsConfig(),
 		testPath: 'TEST_PATH',
 		cacheDir: 'CACHE',
-	};
+	} as PluginArgs;
 
 	describe('loading test oracles', () => {
 		it('should not load oracles', async () => {

--- a/proti-pulumi-packages-schema/test/utils.test.ts
+++ b/proti-pulumi-packages-schema/test/utils.test.ts
@@ -3,12 +3,12 @@ import { resetCachedConfig } from '../src/config';
 import { initModule } from '../src/utils';
 
 describe('init module', () => {
-	const pluginArgs: PluginArgs = {
+	const pluginArgs = {
 		moduleLoader: new (jest.fn<ModuleLoader, []>())(),
 		pluginsConfig: {},
 		testPath: '',
 		cacheDir: '',
-	};
+	} as PluginArgs;
 
 	beforeEach(() => resetCachedConfig());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,7 +1123,6 @@ __metadata:
   resolution: "@proti-iac/core@workspace:proti-core"
   dependencies:
     "@jest/environment": ^29.7.0
-    "@jest/transform": ^29.7.0
     "@jest/types": ^29.6.3
     "@proti-iac/spec": "workspace:^"
     "@pulumi/pulumi": ^3.91.1


### PR DESCRIPTION
Provides plugins on initialization access to:
* Jest's global and project config
* Jest environment
* Resolver and in-memory HasteFS
* ProTI config
* Pulumi project

Resolves #16 