### PR TITLE
Move result types to @proti-iac/core

### DIFF
--- a/proti-core/src/index.ts
+++ b/proti-core/src/index.ts
@@ -6,6 +6,7 @@ export * from './generator';
 export * from './pulumi-project';
 export * from './oracle';
 export * from './plugin';
+export * from './result';
 export * from './spec-impl';
 export * from './test-coordinator';
 export * from './utils';

--- a/proti-core/src/result.ts
+++ b/proti-core/src/result.ts
@@ -1,0 +1,34 @@
+import type { RunDetailsCommon } from 'fast-check';
+import type { DeepReadonly } from './utils';
+
+export type Result = DeepReadonly<{
+	title: string;
+	start: number;
+	end: number;
+	duration: number;
+	errors: Error[];
+}>;
+export type SerializableResult = Omit<Result, 'errors'> & DeepReadonly<{ errors: string[] }>;
+
+export type RunResult = Result &
+	DeepReadonly<{
+		generator: string;
+	}>;
+export type SerializableRunResult = Omit<RunResult, 'errors'> & DeepReadonly<{ errors: string[] }>;
+
+export type CheckResult = DeepReadonly<
+	Pick<
+		RunDetailsCommon<unknown>,
+		'failed' | 'interrupted' | 'numRuns' | 'numSkips' | 'numShrinks'
+	> & {
+		start: number;
+		end: number;
+		duration: number;
+		runResults: RunResult[];
+		report?: string;
+	}
+>;
+export type SerializableCheckResult = Omit<CheckResult, 'runResults'> &
+	DeepReadonly<{
+		runResults: SerializableRunResult[];
+	}>;

--- a/proti-reporter/package.json
+++ b/proti-reporter/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@proti-iac/core": "workspace:^",
-    "@proti-iac/test-runner": "workspace:^",
     "@types/jest": "^29.5.7",
     "@types/node": "^18.18.8",
     "jest": "^29.7.0",

--- a/proti-reporter/src/reporter.ts
+++ b/proti-reporter/src/reporter.ts
@@ -6,9 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { hrtime } from 'process';
 import { assert } from 'typia';
-import type { DeepReadonly } from '@proti-iac/core';
-
-import type { SerializableCheckResult, SerializableRunResult } from '@proti-iac/test-runner';
+import type { DeepReadonly, SerializableCheckResult, SerializableRunResult } from '@proti-iac/core';
 
 const now: () => bigint = hrtime.bigint;
 const nsToMs = (ms: bigint): number => Number(ms / 1000000n);

--- a/proti-test-runner/src/test-result.ts
+++ b/proti-test-runner/src/test-result.ts
@@ -1,38 +1,5 @@
 import type { AssertionResult, TestResult } from '@jest/test-result';
-import type { DeepReadonly } from '@proti-iac/core';
-import type { RunDetailsCommon } from 'fast-check';
-
-export type Result = DeepReadonly<{
-	title: string;
-	start: number;
-	end: number;
-	duration: number;
-	errors: Error[];
-}>;
-export type SerializableResult = Omit<Result, 'errors'> & DeepReadonly<{ errors: string[] }>;
-
-export type RunResult = Result &
-	DeepReadonly<{
-		generator: string;
-	}>;
-export type SerializableRunResult = Omit<RunResult, 'errors'> & DeepReadonly<{ errors: string[] }>;
-
-export type CheckResult = DeepReadonly<
-	Pick<
-		RunDetailsCommon<unknown>,
-		'failed' | 'interrupted' | 'numRuns' | 'numSkips' | 'numShrinks'
-	> & {
-		start: number;
-		end: number;
-		duration: number;
-		runResults: RunResult[];
-		report?: string;
-	}
->;
-export type SerializableCheckResult = Omit<CheckResult, 'runResults'> &
-	DeepReadonly<{
-		runResults: SerializableRunResult[];
-	}>;
+import type { CheckResult, DeepReadonly, Result, SerializableCheckResult } from '@proti-iac/core';
 
 type RunnerResult = DeepReadonly<{
 	testPath: string;

--- a/proti-test-runner/src/test-runner.ts
+++ b/proti-test-runner/src/test-runner.ts
@@ -13,6 +13,7 @@ import type Runtime from 'jest-runtime';
 import { hrtime } from 'process';
 
 import {
+	type CheckResult,
 	createSpecImpl,
 	Config as ProtiConfig,
 	DeepReadonly,
@@ -26,11 +27,13 @@ import {
 	MutableWaiter,
 	readPulumiProject,
 	type ResourceArgs,
+	type Result,
+	type RunResult,
 	TestCoordinator,
 	createAppendOnlyArray,
 } from '@proti-iac/core';
 
-import { CheckResult, Result, RunResult, toTestResult } from './test-result';
+import { toTestResult } from './test-result';
 
 const now: () => bigint = hrtime.bigint;
 const nsToMs = (ms: bigint): number => Number(ms / 1000000n);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,7 +1184,6 @@ __metadata:
     "@jest/reporters": ^29.7.0
     "@jest/test-result": ^29.7.0
     "@proti-iac/core": "workspace:^"
-    "@proti-iac/test-runner": "workspace:^"
     "@types/jest": ^29.5.7
     "@types/node": ^18.18.8
     csv-stringify: ^6.4.4


### PR DESCRIPTION
This is change removes the accidental dependency between @proti-iac/report and @proti-iac/test-runner and is a preparation to provide plugins access to test results (#21).