### PR TITLE
Add shutdown interface for plugins

### DIFF
--- a/proti-core/src/plugin.ts
+++ b/proti-core/src/plugin.ts
@@ -7,6 +7,7 @@ import type { Config as ProtiConfig, PluginsConfig } from './config';
 import type { ModuleLoader } from './module-loader';
 import type { PulumiProject } from './pulumi-project';
 import type { DeepReadonly } from './utils';
+import type { CheckResult } from './result';
 
 export type PluginArgs = Readonly<{
 	readonly testPath: string;
@@ -23,3 +24,9 @@ export type PluginArgs = Readonly<{
 	readonly pulumiProject: PulumiProject;
 }>;
 export type PluginInitFn = (config: PluginArgs) => Promise<void>;
+export const getPluginInitFn = (val: any): PluginInitFn | void =>
+	typeof val?.init === 'function' ? val.init : undefined;
+
+export type PluginShutdownFn = (result: CheckResult) => Promise<void>;
+export const getPluginShutdownFn = (val: any): PluginShutdownFn | void =>
+	typeof val?.shutdown === 'function' ? val.shutdown : undefined;

--- a/proti-core/test/test-coordinator-tests/arbitrary-shutdown.ts
+++ b/proti-core/test/test-coordinator-tests/arbitrary-shutdown.ts
@@ -1,0 +1,15 @@
+import { EmptyStateGeneratorArbitrary } from '../../src/arbitraries/empty-state-generator-arbitrary';
+import type { CheckResult } from '../../src/result';
+import type { PluginShutdownFn } from '../../src/plugin';
+
+export default EmptyStateGeneratorArbitrary;
+
+// eslint-disable-next-line import/no-mutable-exports
+export let result: CheckResult;
+export const shutdown: PluginShutdownFn = async (checkResult) =>
+	new Promise((done) => {
+		process.nextTick(() => {
+			result = checkResult;
+			done();
+		});
+	});

--- a/proti-core/test/test-coordinator-tests/oracle-shutdown.ts
+++ b/proti-core/test/test-coordinator-tests/oracle-shutdown.ts
@@ -1,0 +1,43 @@
+/* eslint-disable class-methods-use-this */
+import type {
+	AsyncDeploymentOracle,
+	AsyncResourceOracle,
+	DeploymentOracle,
+	ResourceOracle,
+} from '../../src/oracle';
+import type { PluginShutdownFn } from '../../src/plugin';
+import type { CheckResult } from '../../src/result';
+
+class Oracle
+	implements
+		ResourceOracle<{}>,
+		AsyncResourceOracle<{}>,
+		DeploymentOracle<{}>,
+		AsyncDeploymentOracle<{}>
+{
+	name = 'Test';
+
+	description = 'Test';
+
+	newRunState = () => ({});
+
+	validateResource = () => undefined;
+
+	asyncValidateResource = async () => undefined;
+
+	validateDeployment = () => undefined;
+
+	asyncValidateDeployment = async () => undefined;
+}
+
+export default Oracle;
+
+// eslint-disable-next-line import/no-mutable-exports
+export let result: CheckResult;
+export const shutdown: PluginShutdownFn = async (checkResult) =>
+	new Promise((done) => {
+		process.nextTick(() => {
+			result = checkResult;
+			done();
+		});
+	});

--- a/proti-test-runner/src/test-runner.ts
+++ b/proti-test-runner/src/test-runner.ts
@@ -304,7 +304,7 @@ const runProti = async (
 	const report = fc.defaultReportMessage(checkDetails);
 
 	const end = now();
-	return (({ failed, interrupted, numRuns, numShrinks, numSkips }) => ({
+	const checkResult = (({ failed, interrupted, numRuns, numShrinks, numSkips }) => ({
 		failed,
 		interrupted,
 		start: nsToMs(start),
@@ -316,6 +316,8 @@ const runProti = async (
 		runResults: runStats,
 		report,
 	}))(checkDetails);
+	testCoordinator.shutdown(checkResult);
+	return checkResult;
 };
 
 const testRunner = async (

--- a/proti-test-runner/src/test-runner.ts
+++ b/proti-test-runner/src/test-runner.ts
@@ -298,7 +298,7 @@ const runProti = async (
 	};
 	const start = now();
 	const checkDetails = await fc.check(
-		fc.asyncProperty(await testCoordinator.arbitrary, testPredicate),
+		fc.asyncProperty(await testCoordinator.generatorArbitrary, testPredicate),
 		proti.testRunner as fc.Parameters<[Generator]>
 	);
 	const report = fc.defaultReportMessage(checkDetails);

--- a/proti-test-runner/test/test-runner-plugin-lifecycle.e2e.test.ts
+++ b/proti-test-runner/test/test-runner-plugin-lifecycle.e2e.test.ts
@@ -1,0 +1,32 @@
+import * as cp from 'child_process';
+import path from 'path';
+import type { Config, DeepPartial } from '@proti-iac/core';
+import { jestCmd } from './util';
+
+describe('runner plugin lifecycle hooks spec end-to-end', () => {
+	const project = '../../examples/s3-website/flat';
+	const protiConfig: DeepPartial<Config> = {
+		testRunner: { numRuns: 2 },
+		testCoordinator: { oracles: [path.resolve(__dirname, './test-runner-test-plugin.js')] },
+	};
+	const jestConfig = { globals: { proti: protiConfig } };
+
+	it('should invoke all lifecycle hooks', () => {
+		expect(cp.execSync(jestCmd([project], jestConfig)).toString()).toBe(`TEST_PLUGIN: init
+TEST_PLUGIN: constructor
+TEST_PLUGIN: newRunState
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: newRunState
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: validateResource
+TEST_PLUGIN: shutdown
+`)
+	});
+});

--- a/proti-test-runner/test/test-runner-test-plugin.js
+++ b/proti-test-runner/test/test-runner-test-plugin.js
@@ -1,0 +1,25 @@
+// eslint-disable-next-line no-underscore-dangle
+exports.__esModule = true;
+
+class Oracle {
+	name = 'Test';
+
+	description = 'Test';
+
+	constructor() {
+		console.info('TEST_PLUGIN: constructor');
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	newRunState = () => {
+		console.info('TEST_PLUGIN: newRunState');
+		return {};
+	};
+
+	// eslint-disable-next-line class-methods-use-this
+	validateResource = () => console.info('TEST_PLUGIN: validateResource');
+}
+
+exports.default = Oracle;
+exports.init = async () => console.info('TEST_PLUGIN: init');
+exports.shutdown = async () => console.info('TEST_PLUGIN: shutdown');


### PR DESCRIPTION
Enable ProTI plugins to implement and export a `shutdown` function that is invoked with the `CheckResult` results summary after ProTI completed checking the IaC program.
Part of #21 